### PR TITLE
Write recipients.bk before writing recipients. 

### DIFF
--- a/auxin_cli/src/state.rs
+++ b/auxin_cli/src/state.rs
@@ -724,7 +724,9 @@ impl AuxinStateManager for StateManager {
 		let our_path = self.get_protocol_store_path(context);
 
 		let mut recipients_path = our_path.clone();
+		let mut recipients_bk_path = recipients_path.clone();
 		recipients_path.push_str("recipients-store");
+		recipients_bk_path.push_str(".bk");
 
 		let mut file = OpenOptions::new()
 			.truncate(true)
@@ -734,6 +736,15 @@ impl AuxinStateManager for StateManager {
 
 		// Save recipient store:
 		let json_recipient_structure = serde_json::to_string_pretty(&context.peer_cache)?;
+		let mut bk_file = OpenOptions::new()
+			.truncate(true)
+			.write(true)
+			.create(true)
+			.open(recipients_bk_path.clone())?;
+
+		bk_file.write_all(json_recipient_structure.as_bytes())?;
+		bk_file.flush()?;
+		drop(bk_file);
 
 		file.write_all(json_recipient_structure.as_bytes())?;
 		file.flush()?;


### PR DESCRIPTION
Write bk file before writing to recipients store, lest there be a brief period of time where there's no persistent record of recipients.