### PR TITLE
Fix for missingDevices/extraDevices issue

### DIFF
--- a/auxin_refactor_plans.md
+++ b/auxin_refactor_plans.md
@@ -1,0 +1,13 @@
+The absolute most critical change we need to make is to generalize over common Signal web API request types (i.e. uploading to CDN, downloading from CDN, signal service requests). The amount of copy-paste gunk this will clear out will probably result in the refactored Auxin being much, much smaller than its current incarnation, even if we're adding features.
+
+Generally speaking the Auxin refactor can have a much lower LoC if we do it right. 
+
+* Have an explicit ***ServiceConfiguration*** type, as an enum. Separate (not-tightly-coupled) functions like `get_service_address(&service_configuration) -> &str {...}` - these would not be methods, rather, free-floating functions, so you can define more of them without changing the `ServiceConfiguration`'s type signature. 
+* Replace the `protobuf-codegen-pure` and `protobuf` crates with `Prost` to be consistent with the rest of the Signal ecosystem. 
+* * While I'm on the subject of protocol buffers, the hacky but pervasive `fix_protobuf_buf()` has got to go. 
+* Store different sessions for different peers separately (for direct messages - groups might not permit this)
+* No AuxinApp as defined by the "auxin" crate proper. Instead, you have much less-tightly-coupled parts (one AuxinSession per peer, perhaps) and in crates that implement the i/o required to make a full Auxin app like auxin-cli (and a hypothetical auxin-wasm) we can put these parts together - since the implementation crates know what context they will be executed in, that frees us up to use things like thread-locals and mutexes. This permits much nicer (and less-hacky) concurrency.
+* Separate steps for receiving and decrypting a message- `EncryptedMessage` struct.
+* Eliminate `MessageIn` and `MessageOut`, as they are just the `Content` protocol buffer struct with a few of its fields duplicated. This seemed necessary before I fully understood the problem space, but now they just seem pointless. 
+* Get rid of `customerror` completely. Replace with either `thiserror` (looks promising) or just plain Rust enums.
+* Statefulness primitives should include functionality for caching attachments and other large blobs, either directly or by exposing some kind of hooks (jsonrpc?).


### PR DESCRIPTION
I was notified by Ilia that, occasionally, attempting to send a message via auxin-cli would result in a 409 response being sent back by Signal's web API. This happened when the recipient had either added or removed a linked device. The body of this response was a json object following the form of `{"missingDevices":[1,2,3], "extraDevices":[4,5,6]}`

The changes I've made in this pull request appear to fix the issue. Now, this type of response is checked for explicitly (other http errors are propagated normally). In send_message(), if an error response is received with a json object in the body containing a missingDevices and extraDevices list, Auxin will clear out the existing device lists and attempt to fetch them with `fill_peer_info()`. If that succeeds without erroring, Auxin then attempts to re-send the message. 