### PR TITLE
Implement read receipts and -n flag to disable them.

### DIFF
--- a/auxin/src/context.rs
+++ b/auxin/src/context.rs
@@ -22,8 +22,16 @@ use crate::{
 pub const PROFILE_KEY_LEN: usize = 32;
 pub type ProfileKey = [u8; PROFILE_KEY_LEN];
 
-#[derive(Clone, Debug, Default)]
-pub struct AuxinConfig {}
+#[derive(Clone, Debug)]
+pub struct AuxinConfig {
+	pub enable_read_receipts: bool,
+}
+
+impl Default for AuxinConfig {
+    fn default() -> Self {
+        Self { enable_read_receipts: true }
+    }
+}
 
 /// Basic signal protocol information and key secrets for the local signal node.
 /// This is not intended to be used to represent peers - instead, this is your user account,

--- a/auxin/src/lib.rs
+++ b/auxin/src/lib.rs
@@ -1602,6 +1602,13 @@ where
 				self.send_message(&msg_ok.remote_address.address, receipt)
 					.await
 					.map_err(|e| ReceiveError::SendErr(format!("{:?}", e)))?;
+				// Also send a read receipt if needed.
+				if self.context.config.enable_read_receipts { 
+					let read_receipt = msg_ok.generate_receipt(auxin_protos::ReceiptMessage_Type::READ);
+					self.send_message(&msg_ok.remote_address.address, read_receipt)
+						.await
+						.map_err(|e| ReceiveError::SendErr(format!("{:?}", e)))?;
+				}
 			}
 		}
 		info!(

--- a/auxin/src/message.rs
+++ b/auxin/src/message.rs
@@ -455,7 +455,7 @@ impl OutgoingPushMessageList {
 
 /// Does this receipt represent a DELIVERY (on a technical level, the endpoint has gotten the message),
 /// or a READ (a user or program has seen this message)?
-type ReceiptMode = auxin_protos::ReceiptMessage_Type;
+pub type ReceiptMode = auxin_protos::ReceiptMessage_Type;
 
 /// A simple indicator of whether the message is being sent by us, or received by us.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
@@ -1102,8 +1102,6 @@ impl MessageIn {
 	/// Do we need to generate a receipt in response to this Message, and then send that to Signal's servers to indicate it has been received?
 	/// Returns false for receipt messages (no infinite receipt loops) and true for all others.
 	pub fn needs_receipt(&self) -> bool {
-		// TODO: Evaluate if Receipt Messages are ever delivered alongside anything else in the same envelope.
-		#[cfg(TODO)]
 		if let Some(_) = self.content.receipt_message {
 			false
 		} else if self.content.end_session {
@@ -1112,7 +1110,6 @@ impl MessageIn {
 		} else {
 			true
 		}
-		false
 	}
 }
 

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -47,6 +47,9 @@ pub struct AppArgs {
 	#[structopt(short, long, default_value = "state")]
 	pub config: String,
 
+	#[structopt(short, long)]
+	pub no_read_receipt: bool,
+
 	/// Controls which directory to save downloaded attachments to as files.
 	/// Defaults to \"./downloads\"
 	#[structopt(

--- a/auxin_cli/src/main.rs
+++ b/auxin_cli/src/main.rs
@@ -121,13 +121,16 @@ pub async fn main() -> Result<()> {
 		base_dir
 	);
 
+	let mut config = AuxinConfig::default();
 	let cert = load_root_tls_cert().unwrap();
 	let net = crate::net::NetManager::new(cert);
 	let state = crate::state::StateManager::new(&base_dir);
+
+	config.enable_read_receipts = !arguments.no_read_receipt;
 	// Get it to all come together.
 	let mut app = AuxinApp::new(
 		arguments.user.clone(),
-		AuxinConfig {},
+		config,
 		net,
 		state,
 		OsRng::default(),


### PR DESCRIPTION
Auxin_cli will now send read receipts by default. You can disable these receipts with a -n command-line flag. 