### PR TITLE
Feature/version improvements

### DIFF
--- a/auxin_cli/build.rs
+++ b/auxin_cli/build.rs
@@ -1,0 +1,7 @@
+use std::process::Command;
+fn main() {
+    // Make git hash available to the program for versioning. 
+    let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().expect("Could not run 'git' in the build process to retrieve a git hash for versioning.");
+    let git_hash = String::from_utf8(output.stdout).expect("Failed to get a git hash from stdout from the 'git' command.");
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/auxin_cli/build.rs
+++ b/auxin_cli/build.rs
@@ -1,14 +1,31 @@
 use std::process::Command;
 fn main() {
     // Make git hash available to the program for versioning. 
-    let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().expect("Could not run 'git rev-parse' in the build process to retrieve a git hash for versioning.");
+    let output = Command::new("git").args(&[
+        "--git-dir", 
+        "../.git",
+        "--work-tree", 
+        "..",
+        "rev-parse", 
+        "--short", 
+        "HEAD"]).output()
+        .expect("Could not run 'git rev-parse' in the build process to retrieve a git hash for versioning.");
     let git_hash = String::from_utf8(output.stdout).expect("Failed to get a git hash from stdout from the 'git' command.");
 
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 
-    let output = Command::new("git").args(&["status", "--short"]).output().expect("Could not run 'git status' in the build process to retrieve a git hash for versioning.");
-    let modified_list = String::from_utf8(output.stdout).expect("Failed to ascertain repository-dirty status from the 'git' command.");
-    if modified_list.len() > 0 { 
-        println!("cargo:rustc-cfg=git_untracked");
+    let second_command = Command::new("git").args(&[
+        "--git-dir", 
+        "../.git",
+        "--work-tree", 
+        "..",
+        "status", 
+        "--short"]).output()
+        .expect("Could not run 'git status' in the build process to retrieve a git hash for versioning.");
+    let modified_list = String::from_utf8(second_command.stdout).expect("Failed to ascertain repository-dirty status from the 'git' command.");
+    if modified_list.len() > 1 { 
+        println!("cargo:rustc-cfg=git_untracked=\"true\"");
+    } else { 
+        println!("cargo:rustc-cfg=git_untracked=\"false\"");
     }
 }

--- a/auxin_cli/build.rs
+++ b/auxin_cli/build.rs
@@ -1,7 +1,14 @@
 use std::process::Command;
 fn main() {
     // Make git hash available to the program for versioning. 
-    let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().expect("Could not run 'git' in the build process to retrieve a git hash for versioning.");
+    let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().expect("Could not run 'git rev-parse' in the build process to retrieve a git hash for versioning.");
     let git_hash = String::from_utf8(output.stdout).expect("Failed to get a git hash from stdout from the 'git' command.");
+
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+    let output = Command::new("git").args(&["status", "--short"]).output().expect("Could not run 'git status' in the build process to retrieve a git hash for versioning.");
+    let modified_list = String::from_utf8(output.stdout).expect("Failed to ascertain repository-dirty status from the 'git' command.");
+    if modified_list.len() > 0 { 
+        println!("cargo:rustc-cfg=git_untracked");
+    }
 }

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -34,9 +34,9 @@ use serde::{Deserialize, Serialize};
 
 pub const AUTHOR_STR: &str = "Forest Contact team";
 
-#[cfg(git_untracked)]
+#[cfg(git_untracked="true")]
 pub const VERSION_STR: &str = concat!(env!("CARGO_PKG_VERSION"),"-",env!("GIT_HASH"), "*");
-#[cfg(not(git_untracked))]
+#[cfg(git_untracked="false")]
 pub const VERSION_STR: &str = concat!(env!("CARGO_PKG_VERSION"),"-",env!("GIT_HASH"));
 
 pub const JSONRPC_VER: &str = "2.0";

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -33,7 +33,7 @@ use structopt::StructOpt;
 use serde::{Deserialize, Serialize};
 
 pub const AUTHOR_STR: &str = "Forest Contact team";
-pub const VERSION_STR: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION_STR: &str = concat!(env!("CARGO_PKG_VERSION"),"-",env!("GIT_HASH"));
 
 pub const JSONRPC_VER: &str = "2.0";
 
@@ -566,6 +566,13 @@ pub async fn process_jsonrpc_input(
 						id: req.id.clone(),
 					}),
 				}
+			},
+			"version" => {
+				JsonRpcResponse::Ok(JsonRpcGoodResponse {
+					jsonrpc: JSONRPC_VER.to_string(),
+					result: serde_json::Value::String(VERSION_STR.to_string()),
+					id: req.id.clone(),
+				})
 			},
 			"upload" => {
 				match serde_json::from_value::<UploadCommand>(req.params) {

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -33,6 +33,10 @@ use structopt::StructOpt;
 use serde::{Deserialize, Serialize};
 
 pub const AUTHOR_STR: &str = "Forest Contact team";
+
+#[cfg(git_untracked)]
+pub const VERSION_STR: &str = concat!(env!("CARGO_PKG_VERSION"),"-",env!("GIT_HASH"), "*");
+#[cfg(not(git_untracked))]
 pub const VERSION_STR: &str = concat!(env!("CARGO_PKG_VERSION"),"-",env!("GIT_HASH"));
 
 pub const JSONRPC_VER: &str = "2.0";

--- a/auxin_cli/src/main.rs
+++ b/auxin_cli/src/main.rs
@@ -102,6 +102,10 @@ pub async fn async_main(exit_oneshot: tokio::sync::oneshot::Sender<i32>) -> Resu
 
 	env_logger::init();
 
+
+	#[cfg(not(git_untracked))]
+	warn!("Could not determine if this build has been modified from the source repository. Please ensure build.rs is being run correctly.");
+
 	/*-----------------------------------------------\\
 	||------------ INIT CONTEXT/IDENTITY ------------||
 	\\-----------------------------------------------*/


### PR DESCRIPTION
Version string is now accessible from JsonRPC (you just need "method"="version"), and it should now contain the truncated Git hash. 