### PR TITLE
Fixes for group cryptography issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.1.15
+
+ * Bugfixes, version command, support sending typing.
+ * PRs #55, #56, #57, #58
+
+## 0.1.14
+
+ * Groups V2!
+ * PR #54
+
+## 0.1.12
+
+ * Async / tokio refactoring, PR #51
+
+## 0.1.11
+
+ * Fix sealed sender (PR #48)
 
 ## 0.1.7
 

--- a/auxin/Cargo.toml
+++ b/auxin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auxin"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/auxin/src/address.rs
+++ b/auxin/src/address.rs
@@ -21,11 +21,30 @@ custom_error! {pub AddressError
 }
 
 //NOTE: UUID changes when phone number is re-registered.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialOrd, Serialize, Deserialize, Hash)]
 pub enum AuxinAddress {
 	Phone(E164),
 	Uuid(Uuid),
 	Both(E164, Uuid),
+}
+
+impl PartialEq for AuxinAddress {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Phone(l0), Self::Phone(r0)) => l0 == r0,
+            (Self::Uuid(l0), Self::Uuid(r0)) => l0 == r0,
+            (Self::Both(l0, l1), Self::Both(r0, r1)) => l0 == r0 || l1 == r1,
+
+            (Self::Uuid(l), Self::Both(_, r1)) => l == r1,
+            (Self::Phone(l), Self::Both(r0, _)) => l == r0,
+
+            (Self::Both(_, l1), Self::Uuid(r)) => l1 == r,
+            (Self::Both(l0, _), Self::Phone(r)) => l0 == r,
+
+            (Self::Phone(_), Self::Uuid(_)) => false,
+            (Self::Uuid(_), Self::Phone(_)) => false,
+        }
+    }
 }
 
 impl std::fmt::Display for AuxinAddress {

--- a/auxin/src/groups/group_storage.rs
+++ b/auxin/src/groups/group_storage.rs
@@ -88,7 +88,7 @@ impl From<GroupMemberInfo> for GroupMemberStorage {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GroupInfo {
 	pub revision: u32,
 	pub master_key: [u8; GROUP_MASTER_KEY_LEN],

--- a/auxin/src/groups/mod.rs
+++ b/auxin/src/groups/mod.rs
@@ -46,6 +46,8 @@ use crate::{
 	LocalIdentity,
 };
 
+use self::group_storage::LocalDistributionRecord;
+
 pub const LIVE_ZKGROUP_SERVER_PUBLIC_PARAMS: &str = "AMhf5ywVwITZMsff/eCyudZx9JDmkkkbV6PInzG4p8x3VqVJSFiMvnvlEKWuRob/1eaIetR31IYeAbm0NdOuHH8Qi+Rexi1wLlpzIo1gstHWBfZzy1+qHRV5A4TqPp15YzBPm0WSggW6PbSn+F4lf57VCnHF7p8SvzAA2ZZJPYJURt8X7bbg+H3i+PEjH9DXItNEqs2sNcug37xZQDLm7X36nOoGPs54XsEGzPdEV+itQNGUFEjY6X9Uv+Acuks7NpyGvCoKxGwgKgE5XyJ+nNKlyHHOLb6N1NuHyBrZrgtY/JYJHRooo5CEqYKBqdFnmbTVGEkCvJKxLnjwKWf+fEPoWeQFj5ObDjcKMZf2Jm2Ae69x+ikU5gBXsRmoF94GXQ==";
 
 pub fn get_server_public_params() -> ServerPublicParams {
@@ -771,6 +773,7 @@ pub struct GroupMemberInfo {
 	pub profile_key: Option<zkgroup::profiles::ProfileKey>,
 	pub member_role: auxin_protos::protos::groups::Member_Role,
 	pub joined_at_revision: u32,
+	pub last_distribution: Option<LocalDistributionRecord>,
 }
 impl PartialEq for GroupMemberInfo {
 	fn eq(&self, other: &Self) -> bool {
@@ -835,6 +838,8 @@ pub fn validate_group_member(
 		profile_key,
 		member_role: group_member.get_role(),
 		joined_at_revision: group_member.get_joinedAtRevision(),
+		//Start assuming we haven't sent one yet. 
+    	last_distribution: None,
 	})
 }
 

--- a/auxin/src/groups/sender_key.rs
+++ b/auxin/src/groups/sender_key.rs
@@ -284,7 +284,7 @@ pub async fn process_sender_key<Store: SenderKeyStore>(
 	sender_key_name: SenderKeyName,
 	distribution_message: SenderKeyDistributionMessage,
 	ctx: &SignalCtx,
-) -> Result<(), SignalProtocolError> {
+) -> Result<SenderKeyRecord, SignalProtocolError> {
 	let mut record = load_or_new_key(sender_key_store, &sender_key_name, ctx).await?;
 	record.add_sender_key_state(
 		CIPHERTEXT_MESSAGE_VERSION,
@@ -304,7 +304,7 @@ pub async fn process_sender_key<Store: SenderKeyStore>(
 			ctx.get(),
 		)
 		.await?;
-	Ok(())
+	Ok(record)
 }
 
 /// Construct a group session for sending messages.

--- a/auxin/src/lib.rs
+++ b/auxin/src/lib.rs
@@ -2124,7 +2124,7 @@ where
 		&mut self,
 		data_message: &auxin_protos::DataMessage,
 		remote_address: &AuxinDeviceAddress,
-	) -> std::result::Result<(), GroupsError> {
+	) -> std::result::Result<Option<GroupId>, GroupsError> {
 		// GroupsV1
 		if data_message.has_group() {
 			let group_context = data_message.get_group();
@@ -2258,13 +2258,15 @@ where
 					}
 				}
 			}*/
+
+				return Ok(Some(GroupId::V2(group_id)));
 			} else {
 				return Err(GroupsError::InvalidMasterKeyLength(
 					group_context.get_masterKey().len() as usize,
 				));
 			}
 		}
-		Ok(())
+		Ok(None)
 	}
 
 	/// Record group information from an incoming message. 
@@ -2277,18 +2279,20 @@ where
 		&mut self,
 		content: &auxin_protos::Content,
 		remote_address: &AuxinDeviceAddress,
-	) -> std::result::Result<(), HandleEnvelopeError> {
+	) -> std::result::Result<Option<GroupId>, HandleEnvelopeError> {
 		if content.has_senderKeyDistributionMessage() {
 			debug!("Got SenderKeyDistributionMessage from {:?}", remote_address);
 			self.check_sender_key_distribution(content, remote_address)
 				.await?;
 		}
-		if content.has_dataMessage() {
+		let group_id_maybe = if content.has_dataMessage() {
 			let data_message = content.get_dataMessage();
 			self.inner_update_groups_from(data_message, remote_address)
-				.await?;
-		}
-		Ok(())
+				.await?
+		} else { 
+			None
+		};
+		Ok(group_id_maybe)
 	}
 
 	/// Handle a received envelope and decode it into a MessageIn if it represents data meant to be read by the end user.
@@ -2311,7 +2315,7 @@ where
 					"Start of decrypting a standard ciphertext message at {}",
 					generate_timestamp()
 				);
-				let result =
+				let mut result =
 					MessageIn::from_ciphertext_message(envelope, &mut self.context, &mut self.rng)
 						.await?;
 
@@ -2325,15 +2329,19 @@ where
 				}
 
 				//Handle possible sender key distribution message.
-				if let Some(content) = &result.content.source {
+				let group_maybe = if let Some(content) = &result.content.source {
 					self.update_groups_from(content, &result.remote_address)
-						.await?;
+						.await?
 				}
+				else { 
+					None
+				};
 
 				info!(
 					"End of decrypting a standard ciphertext message at {}",
 					generate_timestamp()
 				);
+				result.group_id = group_maybe.map(|val| val.to_base64());
 				//Return
 				result
 			})),
@@ -2430,6 +2438,7 @@ where
 					timestamp: envelope.get_timestamp(),
 					timestamp_received: generate_timestamp(),
 					server_guid: envelope.get_serverGuid().to_string(),
+					group_id: None,
 				};
 
 				self.record_ids_from_message(&result).await.unwrap();
@@ -2468,7 +2477,7 @@ where
 					"Start of decrypting a sealed-sender message at {}",
 					generate_timestamp()
 				);
-				let result = MessageIn::from_sealed_sender(envelope, &mut self.context).await?;
+				let mut result = MessageIn::from_sealed_sender(envelope, &mut self.context).await?;
 
 				self.record_ids_from_message(&result).await.unwrap();
 
@@ -2480,10 +2489,15 @@ where
 				}
 
 				//Handle possible sender key distribution message.
-				if let Some(content) = &result.content.source {
+				let group_maybe = if let Some(content) = &result.content.source {
 					self.update_groups_from(content, &result.remote_address)
-						.await?;
-				}
+						.await?
+				} 
+				else {
+					None
+				};
+
+				result.group_id = group_maybe.map(|val| val.to_base64());
 
 				info!(
 					"End of decrypting a sealed-sender message at {}",

--- a/auxin/src/message.rs
+++ b/auxin/src/message.rs
@@ -1068,6 +1068,7 @@ pub async fn decrypt_unidentified_sender(
 
 /// Represents any message we have received over Signal
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageIn {
 	pub content: MessageContent,
 	/// The address of the peer we are receiving from.
@@ -1079,6 +1080,8 @@ pub struct MessageIn {
 	/// Timestamp for when we got this message. Technically this is when it was *decoded*, not *received,* but it should be close enough for any metric we're worried about.
 	pub timestamp_received: u64,
 	pub server_guid: String,
+	/// The GroupId of the group this message pertains to (formatted as Base64), if this is a group message.
+	pub group_id: Option<String>,
 }
 
 impl MessageIn {
@@ -1208,6 +1211,7 @@ impl MessageIn {
 			timestamp: envelope.get_timestamp(),
 			timestamp_received: generate_timestamp(), //Keep track of when we got it.
 			server_guid: envelope.get_serverGuid().to_string(),
+			group_id: None,
 		})
 	}
 
@@ -1235,6 +1239,7 @@ impl MessageIn {
 			timestamp: envelope.get_timestamp(),
 			timestamp_received: generate_timestamp(), //Keep track of when we got it.
 			server_guid: envelope.get_serverGuid().to_string(),
+			group_id: None,
 		})
 	}
 
@@ -1283,6 +1288,7 @@ impl MessageIn {
 			timestamp: envelope.get_timestamp(),
 			timestamp_received: generate_timestamp(), //Keep track of when we got it.
 			server_guid: envelope.get_serverGuid().to_string(),
+			group_id: None,
 		})
 	}
 

--- a/auxin/src/message.rs
+++ b/auxin/src/message.rs
@@ -1010,6 +1010,7 @@ pub async fn decrypt_unidentified_sender(
 		CiphertextMessageType::Plaintext => { 
 			let bytes = unidentified_message_content.contents().unwrap();
 			debug!("Received \"Plaintext\" message which is {} bytes long.", bytes.len());
+			debug!("Contents were: {}", String::from_utf8_lossy(bytes));
 
 			bytes.to_vec()
 		}

--- a/auxin_cli/Cargo.toml
+++ b/auxin_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auxin-cli"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -114,7 +114,7 @@ pub struct SendCommand {
 
 	/// Used instead of `destination` to send a message to a group.
 	#[serde(default)]
-	#[structopt(short, long="groupId")]
+	#[structopt(short, long="group-id")]
 	pub group_id: Option<String>,
 
 	/// Add one or more attachments to this message, passed in as a file path to pull from.

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -608,7 +608,7 @@ pub async fn process_jsonrpc_input(
 						let upload_output = handle_upload_command(val, app).await;
 						match upload_output {
 							Ok(attachment_pointers) => { 
-								let result = if attachment_pointers.len() == 0 {
+								let result = if attachment_pointers.is_empty() {
 									serde_json::Value::Null
 								} 
 								else if attachment_pointers.len() == 1 { 

--- a/auxin_cli/src/commands.rs
+++ b/auxin_cli/src/commands.rs
@@ -114,8 +114,8 @@ pub struct SendCommand {
 
 	/// Used instead of `destination` to send a message to a group.
 	#[serde(default)]
-	#[structopt(short, long="group-id")]
-	pub group_id: Option<String>,
+	#[structopt(short, long)]
+	pub group: Option<String>,
 
 	/// Add one or more attachments to this message, passed in as a file path to pull from.
 	#[serde(default)]
@@ -843,7 +843,7 @@ pub async fn handle_send_command(
 			AuxinAddress::try_from(user_id.as_str()).map_err( |e| SendCommandError::BadDestination(user_id.clone(), format!("{}", e)) )?
 		),
 		None => {
-			let group_b64 = cmd.group_id.as_ref().ok_or( SendCommandError::NoDestination )?; 
+			let group_b64 = cmd.group.as_ref().ok_or( SendCommandError::NoDestination )?; 
 			let group_id = GroupId::from_base64(group_b64).map_err( |e| SendCommandError::BadDestination(group_b64.clone(), format!("{}", e)) )?;
 			MessageDest::Group(group_id)
 		},

--- a/auxin_cli/src/state.rs
+++ b/auxin_cli/src/state.rs
@@ -1207,6 +1207,10 @@ and cannot automatically be repaired.",
 		let our_path = self.get_protocol_store_path(context);
 		let sender_key_path = our_path.join("sender-keys");
 
+		if !sender_key_path.exists() { 
+			std::fs::create_dir_all(&sender_key_path)?;
+		}
+
 		for (sender_key_name, sender_key_record_structure) in
 			context.sender_key_store.sender_keys.iter()
 		{
@@ -1328,6 +1332,9 @@ and cannot automatically be repaired.",
 		let our_path = self.get_protocol_store_path(context);
 		let sender_key_path = our_path.join("sender-keys");
 
+		if !sender_key_path.exists() { 
+			std::fs::create_dir_all(&sender_key_path)?;
+		}
 		//Filename {peer id}_{device id}_{distribution id} for peer keys.
 		//{device id}_{distribution id}.self for local keys.
 


### PR DESCRIPTION
Group cryptography issues appear to be fixed by these changes. A number of issues within Auxin have been fixed, and sanity checks have been added. Previously, identity keys were not being loaded correctly. Also, AuxinAddress equality comparisons required *strict* equality. Now, an AuxinAddress::Phone(phone_number_a) == AuxinAddress::Both(phone_number_a, _). Over-all, testing has shown this is reliable in situations where Auxin would have previously failed. More testing pending.